### PR TITLE
Fix Background Image Not Showing

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -24,7 +24,7 @@ function cwv3_get_css() {
 	$custom_css = get_option( 'cwv3_css', '' );
 	$opacity    = get_option( 'cwv3_bg_opacity', '' );
 
-	$bg_image_css = ! empty( $image ) ? 'background-image: url( '. esc_url( $image ) . ' ) no-repeat top center;' : '';
+	$bg_image_css = ! empty( $image ) ? 'background: url( '. esc_url( $image ) . ' ) no-repeat top center;' : '';
 	$bg_color_css = ! empty( $color ) ? 'background-color: ' . $color['color'] . ';' : '';
 
 	ob_start();


### PR DESCRIPTION
This should fix the problem in bug #37 where background images do not show.  This is happening because the css property 'background-image' only accepts a 'url()' value.  (http://www.w3schools.com/cssref/pr_background-image.asp)

Change made on line 27 from 

$bg_image_css = ! empty( $image ) ? 'background-image: url( '. esc_url( $image ) . ' ) no-repeat top center;' : '';


to 


$bg_image_css = ! empty( $image ) ? 'background: url( '. esc_url( $image ) . ' ) no-repeat top center;' : '';